### PR TITLE
fix ref to EMS mortar svg

### DIFF
--- a/strategems.json
+++ b/strategems.json
@@ -268,7 +268,7 @@
       "name": "A/M-23 EMS Mortar Sentry",
       "category": "Defensive",
       "command": [2,0,3,2,3],
-      "icon_name": "Mortar Sentry.svg"
+      "icon_name": "EMS Mortar Sentry.svg"
     },
     "45": {
       "name": "Orbital Gatling Barrage",


### PR DESCRIPTION
The EMS mortar currently uses the icon of the normal mortar.
This PR will make it use the correct one