### PR TITLE
Minor settings cleanup

### DIFF
--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -24,6 +24,22 @@ class Settings:
         return cls._instance
 
     def __init__(self):
+        # Load settings from file, use defaults if there is no file
+        if not self.loadFromFile():
+            self.loadDefaults()
+        ## Consider no version to be version 1
+        if not hasattr(self, "version") or self.version < 2:
+            self.migrate_1_to_2()
+        ## For future use:
+        # if self.version == 2:
+        #     self.migrate_2_to_3()
+        print("Settings initialized")
+
+    def loadDefaults(self):
+        """
+        We load a base set of settings, in case the user has no settings file.
+        """
+        self.version = 2
         self.loadouts = {utilities.generateUuid(): Loadout("Loadout 1", {"1": "1"})}
         self.triggerKey = "ctrl"
         self.triggerDelay = 100
@@ -35,29 +51,32 @@ class Settings:
         self.globalArmKey = None
         self.globalArmMode = constants.ARM_MODE_TOGGLE
         self.view_framework = constants.VIEW_PYQT5
-        self.loadFromFile()
-        ## Consider no version to be version 1
-        if not hasattr(self, "version") or self.version < 2:
-            self.migrate_1_to_2()
-        ## For future use:
-        # if self.version == 2:
-        #     self.migrate_2_to_3()
-        print("Settings initialized")
 
     def loadFromFile(self):
         try:
             with open(constants.SETTINGS_PATH) as json_file:
                 data = json.load(json_file)
-                for attribute, value in data.items():
-                    setattr(self, attribute, value)
-                    if attribute == "loadouts":
-                        loadouts = {}
-                        for id, item in value.items():
-                            loadout = Loadout(**item)
-                            loadouts[id] = loadout
-                        self.loadouts = loadouts
+                if 'loadouts' in data:
+                    self.parseLoadouts(data['loadouts'])
+                self.parseSettings(data)
+            return True
         except (OSError, json.JSONDecodeError):
-            pass  # we use defaults if there's an error reading or decoding the file
+            return False
+
+    def parseLoadouts(self, loadout_data):
+        # We expect the root loadouts element
+        loadouts = {}
+        for id, item in loadout_data.items():
+            loadout = Loadout(item['name'], item['macroKeys'])
+            loadouts[id] = loadout
+        self.loadouts = loadouts
+
+    def parseSettings(self, settings_data):
+        for attribute, value in settings_data.items():
+            # Exclude 'loadouts' from this general assignment because it's already processed
+            if attribute != 'loadouts':
+                setattr(self, attribute, value)
+
 
     def saveToFile(self):
         with open(constants.SETTINGS_PATH, "w") as file:

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -24,9 +24,10 @@ class Settings:
         return cls._instance
 
     def __init__(self):
-        # Load settings from file, use defaults if there is no file
-        if not self.loadFromFile():
-            self.loadDefaults()
+        # Load defaults, protecting against missing values
+        self.loadDefaults()
+        # Load settings from file, overriding defaults as needed
+        self.loadFromFile()
         ## Consider no version to be version 1
         if not hasattr(self, "version") or self.version < 2:
             self.migrate_1_to_2()
@@ -39,7 +40,6 @@ class Settings:
         """
         We load a base set of settings, in case the user has no settings file.
         """
-        self.version = 2
         self.loadouts = {utilities.generateUuid(): Loadout("Loadout 1", {"1": "1"})}
         self.triggerKey = "ctrl"
         self.triggerDelay = 100

--- a/src/view/pyqt5/main.py
+++ b/src/view/pyqt5/main.py
@@ -3,6 +3,7 @@ from PyQt5.QtGui import QIcon, QFont, QPixmap
 from PyQt5.QtCore import Qt
 from PyQt5.QtSvg import QSvgWidget
 from src import constants
+from src.classes.settings import Settings
 from src.executer_arduino import ArduinoPassthroughExecuter
 from src.view.pyqt5.filter_dialog import FilteredListDialog
 from src.view.pyqt5.edit_config_dialog import EditConfigDialog
@@ -132,7 +133,8 @@ class MainWindow(QMainWindow):
     
     def update_loadout_menu_items(self):
         self.loadout_menu.clear()
-        for loadoutId, loadout in self.controller.model.settings.loadouts.items():
+        settings = Settings.getInstance()
+        for loadoutId, loadout in settings.loadouts.items():
             loadout_action = QAction(loadout.name, self)
             loadout_action.triggered.connect(lambda checked, loadoutId=loadoutId: self.controller.set_active_loadout(loadoutId))
             self.loadout_menu.addAction(loadout_action)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -41,12 +41,13 @@ def test_configuration_should_be_migrated_when_version_is_old(mock_migrate_metho
     Settings.getInstance()
     # Confirm that migrate_1_to_2 was called once.
     mock_migrate_method.assert_called_once()
-    @patch("builtins.open", new_callable=mock_open, read_data='{"stratagemKeys": ["w", "a", "s", "d"], "strategemKeyDelay": 50, "strategemKeyDelayJitter": 20}')
-    @patch("src.classes.settings.Settings.migrate_1_to_2", new_callable=MagicMock)
-    def test_configuration_should_be_migrated_when_version_is_old(self, mock_migrate_method, mock_file):
-        Settings.getInstance()
-        # Confirm that migrate_1_to_2 was called once.
-        mock_migrate_method.assert_called_once()
+
+@patch("builtins.open", new_callable=mock_open, read_data='{"stratagemKeys": ["w", "a", "s", "d"], "strategemKeyDelay": 50, "strategemKeyDelayJitter": 20}')
+@patch("src.classes.settings.Settings.migrate_1_to_2", new_callable=MagicMock)
+def test_configuration_should_be_migrated_when_version_is_old(mock_migrate_method, mock_file):
+    Settings.getInstance()
+    # Confirm that migrate_1_to_2 was called once.
+    mock_migrate_method.assert_called_once()
 
 
 @patch("builtins.open", new_callable=mock_open, read_data='{"stratagemKeys": ["w", "a", "s", "d"], "strategemKeyDelay": 50, "strategemKeyDelayJitter": 20}')


### PR DESCRIPTION
On review, I found minor issues. a settings test did not run, and failed when activated. Fixed lead to clean-code based readability to settings constructor. Also change a settings reference to singleton use, rather than deep reference.