### PR TITLE
Allow browsing loadouts using hotkeys

### DIFF
--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -117,9 +117,15 @@ class Settings:
 
     def saveToFile(self):
         with open(constants.SETTINGS_PATH, "w") as file:
-            settings_as_json = json.dumps(self, default=vars, indent=2)
+            # Custom function for filtering attributes
+            def filter_attributes(obj):
+                return {
+                    key: value for key, value in vars(obj).items() 
+                    if not key.startswith('_')  # Exclude private attributes
+                }
+            settings_as_json = json.dumps(self, default=filter_attributes, indent=2)
             file.write(settings_as_json)
-
+            
     def migrate_1_to_2(self):
         self.version = 2
         if hasattr(self, "strategemKeys"):

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -46,6 +46,8 @@ class Settings:
         self.globalArmKey = None
         self.globalArmMode = constants.ARM_MODE_TOGGLE
         self.view_framework = constants.VIEW_PYQT5
+        self.nextLoadoutKey = "+"
+        self.prevLoadoutKey = "-"
 
     def loadFromFile(self):
         try:

--- a/src/controller.py
+++ b/src/controller.py
@@ -59,9 +59,6 @@ class Controller:
         
         # Set the next loadout as active
         self.set_active_loadout(loadout_ids[next_index])
-        
-        # Debug information
-        print(f"DEBUG: New loadout selected: {self.model.currentLoadout.name}")
 
     def cycle_prev_loadout(self):
         # Get current active loadout ID and available loadout IDs
@@ -74,9 +71,6 @@ class Controller:
         
         # Set the next loadout as active
         self.set_active_loadout(loadout_ids[prev_index])
-        
-        # Debug information
-        print(f"DEBUG: New loadout selected: {self.model.currentLoadout.name}")
 
     def update_title_description(self, description):
         self.view.update_title_description(description)

--- a/src/controller.py
+++ b/src/controller.py
@@ -47,30 +47,18 @@ class Controller:
         if isArmed:
             self.executer.prepare()
         self.view.update_armed()
-    
-    def cycle_next_loadout(self):
-        # Get current active loadout ID and available loadout IDs
-        current_loadout_id = self.model.currentLoadoutId
-        loadout_ids = list(self.model.settings.loadouts.keys())
-        
-        # Calculate the index of the next loadout
-        current_index = loadout_ids.index(current_loadout_id)
-        next_index = (current_index + 1) % len(loadout_ids)
-        
-        # Set the next loadout as active
-        self.set_active_loadout(loadout_ids[next_index])
 
-    def cycle_prev_loadout(self):
+    def cycle_loadout(self, offset):
         # Get current active loadout ID and available loadout IDs
         current_loadout_id = self.model.currentLoadoutId
         loadout_ids = list(self.model.settings.loadouts.keys())
         
         # Calculate the index of the next loadout
         current_index = loadout_ids.index(current_loadout_id)
-        prev_index = (current_index - 1 + len(loadout_ids)) % len(loadout_ids)
+        new_index = (current_index + offset + len(loadout_ids)) % len(loadout_ids)
         
         # Set the next loadout as active
-        self.set_active_loadout(loadout_ids[prev_index])
+        self.set_active_loadout(loadout_ids[new_index])
 
     def update_title_description(self, description):
         self.view.update_title_description(description)

--- a/src/controller.py
+++ b/src/controller.py
@@ -58,13 +58,10 @@ class Controller:
         next_index = (current_index + 1) % len(loadout_ids)
         
         # Set the next loadout as active
-        self.model.set_active_loadout(loadout_ids[next_index])
+        self.set_active_loadout(loadout_ids[next_index])
         
         # Debug information
         print(f"DEBUG: New loadout selected: {self.model.currentLoadout.name}")
-        
-        # FIXME: Issue with updating the view due to threading
-        # self.view.update_current_loadout()
 
     def cycle_prev_loadout(self):
         # Get current active loadout ID and available loadout IDs
@@ -76,13 +73,10 @@ class Controller:
         prev_index = (current_index - 1 + len(loadout_ids)) % len(loadout_ids)
         
         # Set the next loadout as active
-        self.model.set_active_loadout(loadout_ids[prev_index])
+        self.set_active_loadout(loadout_ids[prev_index])
         
         # Debug information
         print(f"DEBUG: New loadout selected: {self.model.currentLoadout.name}")
-        
-        # FIXME: Issue with updating the view due to threading
-        # self.view.update_current_loadout()
 
     def update_title_description(self, description):
         self.view.update_title_description(description)

--- a/src/controller.py
+++ b/src/controller.py
@@ -9,7 +9,7 @@ class Controller:
         self.settings = Settings.getInstance()
 
         self.keyListener = PynputKeyListener(self.model, self)
-    
+
     def set_executor(self):
         selectedExecutor = self.settings.selectedExecutor
         if selectedExecutor == constants.EXECUTOR_PYNPUT:
@@ -48,6 +48,42 @@ class Controller:
             self.executer.prepare()
         self.view.update_armed()
     
+    def cycle_next_loadout(self):
+        # Get current active loadout ID and available loadout IDs
+        current_loadout_id = self.model.currentLoadoutId
+        loadout_ids = list(self.model.settings.loadouts.keys())
+        
+        # Calculate the index of the next loadout
+        current_index = loadout_ids.index(current_loadout_id)
+        next_index = (current_index + 1) % len(loadout_ids)
+        
+        # Set the next loadout as active
+        self.model.set_active_loadout(loadout_ids[next_index])
+        
+        # Debug information
+        print(f"DEBUG: New loadout selected: {self.model.currentLoadout.name}")
+        
+        # FIXME: Issue with updating the view due to threading
+        # self.view.update_current_loadout()
+
+    def cycle_prev_loadout(self):
+        # Get current active loadout ID and available loadout IDs
+        current_loadout_id = self.model.currentLoadoutId
+        loadout_ids = list(self.model.settings.loadouts.keys())
+        
+        # Calculate the index of the next loadout
+        current_index = loadout_ids.index(current_loadout_id)
+        prev_index = (current_index - 1 + len(loadout_ids)) % len(loadout_ids)
+        
+        # Set the next loadout as active
+        self.model.set_active_loadout(loadout_ids[prev_index])
+        
+        # Debug information
+        print(f"DEBUG: New loadout selected: {self.model.currentLoadout.name}")
+        
+        # FIXME: Issue with updating the view due to threading
+        # self.view.update_current_loadout()
+
     def update_title_description(self, description):
         self.view.update_title_description(description)
 

--- a/src/listener_pynput.py
+++ b/src/listener_pynput.py
@@ -5,6 +5,8 @@ class PynputKeyListener:
     def __init__(self, model, controller):
         self.model = model
         self.globalArmKey = key_parser_pynput.parse_key(self.model.settings.globalArmKey)
+        self.nextLoadoutKey = key_parser_pynput.parse_key(self.model.settings.nextLoadoutKey)
+        self.prevLoadoutKey = key_parser_pynput.parse_key(self.model.settings.prevLoadoutKey)
         self.listener = None
         self.controller = controller
         self.listener = keyboard.Listener(on_press=self.on_press, on_release=self.on_release, suppress=False)
@@ -12,9 +14,8 @@ class PynputKeyListener:
         self.getNextCallbacks = []
         self.key_press_handlers = {
             self.globalArmKey: self.handle_global_arm_press,
-            # TODO: Put these keys in settings
-            "+": self.handle_next_loadout,
-            "-": self.handle_prev_loadout,
+            self.nextLoadoutKey: self.handle_next_loadout,
+            self.prevLoadoutKey: self.handle_prev_loadout,
         }
         self.key_release_handlers = {
             self.globalArmKey: self.handle_global_arm_release

--- a/src/listener_pynput.py
+++ b/src/listener_pynput.py
@@ -35,11 +35,9 @@ class PynputKeyListener:
 
     # Loadout browser
     def handle_next_loadout(self, key):
-        # TODO: Actually load next loutout
-        print('Next loadout')
+        self.controller.cycle_next_loadout()
     def handle_prev_loadout(self, key):
-        # TODO: Actually load previous loutout
-        print('Previous loadout')
+        self.controller.cycle_prev_loadout()
 
     ### Helpers ###
     def on_press(self, key):

--- a/src/listener_pynput.py
+++ b/src/listener_pynput.py
@@ -37,10 +37,10 @@ class PynputKeyListener:
     # Loadout browser
     def handle_next_loadout(self, key):
         if(not self.model.isArmed):
-            self.controller.cycle_next_loadout()
+            self.controller.cycle_loadout(+1)
     def handle_prev_loadout(self, key):
         if(not self.model.isArmed):
-            self.controller.cycle_prev_loadout()
+            self.controller.cycle_loadout(-1)
 
     ### Helpers ###
     def on_press(self, key):

--- a/src/listener_pynput.py
+++ b/src/listener_pynput.py
@@ -36,9 +36,11 @@ class PynputKeyListener:
 
     # Loadout browser
     def handle_next_loadout(self, key):
-        self.controller.cycle_next_loadout()
+        if(not self.model.isArmed):
+            self.controller.cycle_next_loadout()
     def handle_prev_loadout(self, key):
-        self.controller.cycle_prev_loadout()
+        if(not self.model.isArmed):
+            self.controller.cycle_prev_loadout()
 
     ### Helpers ###
     def on_press(self, key):

--- a/src/res/stratagems.json
+++ b/src/res/stratagems.json
@@ -195,7 +195,7 @@
     "32": {
       "name": "Eagle Rearm",
       "category": "Mission",
-      "command": [0,0,1,2,3],
+      "command": [0,0,1,2,0,3],
       "icon_name": "Eagle Rearm.svg"
     },
     "33": {
@@ -389,5 +389,17 @@
       "category": "Mission",
       "command": [0,2,0,2,0,2],
       "icon_name": "Tectonic Drill.svg"
+    },
+    "65": {
+      "name": "Prospecting Drill",
+      "category": "Mission",
+      "command": [2,2,1,3,2,2],
+      "icon_name": "Prospecting Drill.svg"
+    },
+    "66": {
+      "name": "Orbital illumination flare",
+      "category": "Mission",
+      "command": [3,3,1,1],
+      "icon_name": "Orbital Illumination Flare.svg"
     }
   }

--- a/src/view/pyqt5/edit_config_dialog.py
+++ b/src/view/pyqt5/edit_config_dialog.py
@@ -63,7 +63,11 @@ class EditConfigDialog(QDialog):
         self.add_settings_headline(self.key_grid_layout, "Global arm bindings")
         self.add_key_binding(self.key_grid_layout, "Global arm", self.settings.globalArmKey, False, lambda: self.show_capture_dialog(SettingsBindingHandler(self, "globalArmKey", self.update_key_settings).on_next_value))
         self.add_key_binding(self.key_grid_layout, "Toggle mode", self.settings.globalArmMode, True, self.open_global_arm_mode_dialog)
-    
+
+        self.add_settings_headline(self.key_grid_layout, "Loadout browsing")
+        self.add_key_binding(self.key_grid_layout, "Next loadout", self.settings.nextLoadoutKey, False, lambda: self.show_capture_dialog(SettingsBindingHandler(self, "nextLoadoutKey", self.update_key_settings).on_next_value))
+        self.add_key_binding(self.key_grid_layout, "Previous loadout", self.settings.prevLoadoutKey, True, lambda: self.show_capture_dialog(SettingsBindingHandler(self, "prevLoadoutKey", self.update_key_settings).on_next_value))
+
     def open_global_arm_mode_dialog(self):
         items = {
             constants.ARM_MODE_PUSH: 'Push',

--- a/src/view/pyqt5/pyqt5.py
+++ b/src/view/pyqt5/pyqt5.py
@@ -1,5 +1,6 @@
 from src.view.view_base import BaseView
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import Qt, pyqtSignal, QObject
 from src.view.pyqt5.main import MainWindow
 
 class PyQT5View(BaseView):
@@ -8,26 +9,56 @@ class PyQT5View(BaseView):
         self.controller = controller
         self.gui = QApplication([])
         self.window = MainWindow(controller)
+        self.setup_ui_update_listener()
+    
+    def setup_ui_update_listener(self):
+        self.ui_listener = UiUpdateListener()
+        self.ui_listener.ui.connect(self.update_ui)
+    
+    def update_ui(self, method_name, arguments):
+        if method_name == self.show_interface.__name__:
+            self.window.show()
+            self.gui.exec()
+        elif method_name == self.update_current_loadout.__name__:
+            self.window.update_current_loadout()
+            self.window.update_macros()
+        elif method_name == self.update_macros.__name__:
+            self.window.update_macros()
+        elif method_name == self.update_armed.__name__:
+            self.window.update_armed()
+        elif method_name == self.on_loadout_changed.__name__:
+            self.window.update_loadout_menu_items()
+        elif method_name == self.update_executor_menu.__name__:
+            self.window.update_executor_menu()
+        elif method_name == self.update_title_description.__name__:
+            self.window.update_title_description(arguments[0])
 
     def show_interface(self):
-        self.window.show()
-        self.gui.exec()
+        self.ui_listener.update(self.show_interface.__name__, [])
     
     def update_macros(self):
-        self.window.update_macros()
+        self.ui_listener.update(self.update_macros.__name__, [])
     
     def update_current_loadout(self):
-        self.window.update_current_loadout()
-        self.window.update_macros()
+        self.ui_listener.update(self.update_current_loadout.__name__, [])
 
     def update_armed(self):
-        self.window.update_armed()
-    
+        self.ui_listener.update(self.update_armed.__name__, [])
+
     def update_title_description(self, description):
-        self.window.update_title_description(description)
+        self.ui_listener.update(self.update_title_description.__name__, [description])
 
     def on_loadout_changed(self):
-        self.window.update_loadout_menu_items()
-    
+        self.ui_listener.update(self.on_loadout_changed.__name__, [])
+
     def update_executor_menu(self):
-        self.window.update_executor_menu()
+        self.ui_listener.update(self.update_executor_menu.__name__, [])
+
+class UiUpdateListener(QObject):
+    ui = pyqtSignal(str, list)
+
+    def __init__(self):
+        super().__init__()
+
+    def update(self, method_name, list):
+        self.ui.emit(method_name, list)


### PR DESCRIPTION
Added hotkeys for cycling through loadouts up and down.

* Ensured hotkeys are disabled when armed
* Keys are configurable from settings
* defaults are present in Settings
* Lightly refactored input handling in PynputKeyListener

Fixes #41 

Known problems: Crash when attempting to reassign key. This problem is also present on main