### PR TITLE
Fix layout for main windows

### DIFF
--- a/src/view/pyqt5/main.py
+++ b/src/view/pyqt5/main.py
@@ -92,6 +92,11 @@ class MainWindow(QMainWindow):
     def update_macros(self):
         self.listwidget.clear()
 
+        header_height = 115  # Height of items above the macrolist
+        vertical_padding = 5 # Padding between items. This  seems to insist on being 5
+
+        # Initial window height
+        height = header_height
         for index, (key, value) in enumerate(self.controller.getAllMacros()):
             listAdapter = QLoadoutListAdapter()
             listAdapter.setKey(key)
@@ -101,10 +106,14 @@ class MainWindow(QMainWindow):
             listAdapterItem = QListWidgetItem(self.listwidget)
             listAdapterItem.setData(Qt.UserRole,key)
             listAdapterItem.setSizeHint(listAdapter.sizeHint())
+
+            # Add items to window height
+            height += int(listAdapter.sizeHint().height()) + vertical_padding
+
             self.listwidget.addItem(listAdapterItem)
             self.listwidget.setItemWidget(listAdapterItem, listAdapter)
 
-        height = 115 + (len(self.controller.getAllMacros())*55)
+        # Resize window
         self.resize(self.geometry().width(), height)
 
     def update_armed(self):

--- a/src/view/pyqt5/main.py
+++ b/src/view/pyqt5/main.py
@@ -92,8 +92,10 @@ class MainWindow(QMainWindow):
     def update_macros(self):
         self.listwidget.clear()
 
-        header_height = 115  # Height of items above the macrolist
-        vertical_padding = 5 # Padding between items. This  seems to insist on being 5
+        # Calculate the height of items above the macrolist
+        header_height = self.hBox.sizeHint().height()
+        header_height += self.armedBar.sizeHint().height()
+        header_height += self.toolbar.sizeHint().height()
 
         # Initial window height
         height = header_height
@@ -108,7 +110,7 @@ class MainWindow(QMainWindow):
             listAdapterItem.setSizeHint(listAdapter.sizeHint())
 
             # Add items to window height
-            height += int(listAdapter.sizeHint().height()) + vertical_padding
+            height += int(listAdapter.sizeHint().height())
 
             self.listwidget.addItem(listAdapterItem)
             self.listwidget.setItemWidget(listAdapterItem, listAdapter)


### PR DESCRIPTION
We now get the item heights dynamically, and add appropriate padding.

Faulty layout (notic scrollbar, and the cut off macro nr. 9):
![image](https://github.com/user-attachments/assets/a527f4f5-38ad-4491-9abb-95b49bf4d3ad)

Fixed version:
![image](https://github.com/user-attachments/assets/45b73770-fbbd-4194-83d8-0ce43d338959)

