### PR TITLE
feat(ui): Reinforce loadouts menu with active indicator

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -148,6 +148,9 @@ class Controller:
     
     def get_active_loadout(self):
         return self._model.loadoutsManager.loadouts.get(self._model.settingsManager.currentLoadoutId, None)
+
+    def get_active_loadout_id(self):
+        return self._model.settingsManager.currentLoadoutId
     
     # Macros
     def getMacroForKey(self, key):

--- a/src/view/pyqt5/main.py
+++ b/src/view/pyqt5/main.py
@@ -143,6 +143,7 @@ class MainWindow(QMainWindow):
             self.loadout.setText(currentLoadout.name.upper()) 
         else:
             self.loadout.setText("")
+        self.update_loadout_menu_items()
 
     def setup_toolbar_menu(self):
         # Create a Files menu

--- a/src/view/pyqt5/main.py
+++ b/src/view/pyqt5/main.py
@@ -181,6 +181,8 @@ class MainWindow(QMainWindow):
         for loadoutId, loadout in self.controller.get_loadouts_manager().loadouts.items():
             loadout_action = QAction(loadout.name, self)
             loadout_action.triggered.connect(lambda checked, loadoutId=loadoutId: self.controller.set_active_loadout(loadoutId))
+            if self.controller.get_active_loadout_id() == loadoutId:
+                loadout_action.setIcon(QIcon(constants.ICON_BASE_PATH+"serial_connected.svg"))
             self.loadout_menu.addAction(loadout_action)
         
         self.loadout_menu.addSeparator()


### PR DESCRIPTION
Alright, soldiers, listen up!

This transmission confirms a critical update to our gear interface. The loadouts menu has been reinforced with a visual indicator—a glorious checkmark of Liberty—to clearly mark the currently active loadout. No more fumbling for the right equipment when the bugs are breathing down your neck!

This completes objective #55.

For Super Earth!